### PR TITLE
Make usernames case insensitive

### DIFF
--- a/src/forgotPassword.js
+++ b/src/forgotPassword.js
@@ -1,17 +1,18 @@
 /* @flow */
 import cognitoRequest from './util/cognitoRequest';
+import formatUsername from './util/formatUsername';
 
 export const forgotPasswordRequest = cognitoRequest('forgotPassword', ({pool, request}: Object): Object => {
     return {
         ClientId: pool.getClientId(),
-        Username: request.body.username
+        Username: formatUsername(request.body.username)
     };
 });
 
 export const forgotPasswordConfirm = cognitoRequest('confirmForgotPassword', ({pool, request}: Object): Object => {
     return {
         ClientId: pool.getClientId(),
-        Username: request.body.username,
+        Username: formatUsername(request.body.username),
         ConfirmationCode: request.body.confirmationCode,
         Password: request.body.password
     };

--- a/src/signIn.js
+++ b/src/signIn.js
@@ -7,6 +7,7 @@ import {
 import Pool from './userPool';
 import {usernameAndPasswordRequired} from './error';
 import {GromitError} from 'gromit';
+import formatUsername from './util/formatUsername';
 
 export default async function signIn(request: Object): Promise<{statusCode: number, body: Object}> {
 
@@ -19,12 +20,12 @@ export default async function signIn(request: Object): Promise<{statusCode: numb
         }
 
         const authenticationDetails = new AuthenticationDetails({
-            Username: username,
+            Username: formatUsername(username),
             Password: password
         });
 
         const user = new CognitoUser({
-            Username: username,
+            Username: formatUsername(username),
             Pool
         });
 

--- a/src/signUp.js
+++ b/src/signUp.js
@@ -3,6 +3,7 @@ import {CognitoUserAttribute} from 'amazon-cognito-identity-js';
 import Pool from './userPool';
 import {usernameAndPasswordRequired} from './error';
 import {GromitError} from 'gromit';
+import formatUsername from './util/formatUsername';
 
 export default async function signUp(request: Object): Promise<{statusCode: number, body: Object}> {
 
@@ -21,7 +22,7 @@ export default async function signUp(request: Object): Promise<{statusCode: numb
                 });
             });
 
-        Pool.signUp(username, password, attributeList, null, async (err: Object, result: Object): Promise<> => {
+        Pool.signUp(formatUsername(username), password, attributeList, null, async (err: Object, result: Object): Promise<> => {
             if (err) {
                 return reject(GromitError.wrap(err));
             }
@@ -33,6 +34,7 @@ export default async function signUp(request: Object): Promise<{statusCode: numb
             return resolve({statusCode: 200, body: {
                 user: {
                     ...request.body,
+                    username: formatUsername(username),
                     sub: result.userSub
                 },
                 verificationAttribute: delivery.AttributeName,

--- a/src/signUpConfirm.js
+++ b/src/signUpConfirm.js
@@ -3,6 +3,7 @@ import {CognitoUser} from 'amazon-cognito-identity-js';
 import Pool from './userPool';
 import {usernameAndVerificationCodeRequired} from './error';
 import {GromitError} from 'gromit';
+import formatUsername from './util/formatUsername';
 
 export default function signUpConfirm(request: Object): Promise<{statusCode: number, body: Object}> {
 
@@ -14,7 +15,7 @@ export default function signUpConfirm(request: Object): Promise<{statusCode: num
         }
 
         const user = new CognitoUser({
-            Username: username,
+            Username: formatUsername(username),
             Pool
         });
 

--- a/src/signUpConfirmResend.js
+++ b/src/signUpConfirmResend.js
@@ -3,6 +3,7 @@ import {CognitoUser} from 'amazon-cognito-identity-js';
 import Pool from './userPool';
 import {usernameRequired} from './error';
 import {GromitError} from 'gromit';
+import formatUsername from './util/formatUsername';
 
 export default function signUpConfirmResend(request: Object): Promise<{statusCode: number, body: Object}> {
     return new Promise((resolve: Function, reject: Function): void => {
@@ -13,7 +14,7 @@ export default function signUpConfirmResend(request: Object): Promise<{statusCod
         }
 
         const user = new CognitoUser({
-            Username: username,
+            Username: formatUsername(username),
             Pool
         });
 

--- a/src/util/formatUsername.js
+++ b/src/util/formatUsername.js
@@ -1,0 +1,4 @@
+export default function(str: ?string): ?string {
+    if(typeof str !== 'string') return null;
+    return str.trim().toLowerCase();
+};

--- a/src/util/formatUsername.js
+++ b/src/util/formatUsername.js
@@ -1,4 +1,5 @@
+//@flow
 export default function(str: ?string): ?string {
     if(typeof str !== 'string') return null;
     return str.trim().toLowerCase();
-};
+}


### PR DESCRIPTION
We always want to compare emails case insensitively but cognito is case sensitive. This update trims and lowercases usernames before they go to cognito.

__This is a breaking change that will mean that any users that are used to logging in with their emails in upper case will no longer be able to log in.__